### PR TITLE
:process_unsaved_changes should empy changes in account

### DIFF
--- a/lib/bank/account.ex
+++ b/lib/bank/account.ex
@@ -63,7 +63,7 @@ defmodule Bank.Account do
 
       {:process_unsaved_changes, saver} ->
         saver.(state.id, :lists.reverse(state.changes))
-        new_state = %{state | :changes => state.changes}
+        new_state = %{state | :changes => []}
         loop(new_state)
 
       {:load_from_history, events} ->


### PR DESCRIPTION
I haven't run code, but I think it's obvious typo - changes should be dropped after they were processed.
